### PR TITLE
filter articles based on flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,23 @@ A CLI app that interacts with Author's Haven
 2. View specific article `node cli.js ah view <article-slug>`
 3. Save specific article to file `node cli.js ah view <article-slug> --save`
 4. Retrieve specific saved article from file `node cli.js ah view <article-slug> --offline`
+5. Filter article with various flags
+`node cli.js ah search <flag_name>=<flag_value> <2nd_flag_name=<2nd_flag_value>`
+
+
+    ### Flags available:
+
+
+        1. author - to get posts by a specific author `author=tevin`
+        2. tag - to get articles with a specific tag `tag=python`
+        3. title - to get articles with a title that matches what is provided `title=flutter`
+        4. page_size - determines the number of articles displayed per page. `page_size=40`
+
+
+
+    Flags can be composed together
+
+    `node cli.js ah search author=tevin tag=python title=flutter page_size=40`
+
+6. To Get help with commands `node cli.js ah help`
+   

--- a/__tests__/test_fetch.js
+++ b/__tests__/test_fetch.js
@@ -1,6 +1,10 @@
 const axios = require("axios");
 
-const { getAllArticles, getSingleArticle } = require("../src/fetch");
+const {
+  getAllArticles,
+  getSingleArticle,
+  getFilteredArticles
+} = require("../src/fetch");
 
 jest.spyOn(axios, "get");
 global.console = { log: jest.fn() };
@@ -63,4 +67,49 @@ test("should raise an error when getting article is unsuccessful", () => {
       "❗❗ Something went wrong fetching the article."
     );
   });
+});
+
+test("should retrieve list of articles upon filtering", () => {
+  axios.get.mockImplementation(() =>
+    Promise.resolve({
+      data: {
+        data: {
+          count: 0,
+          next: null,
+          prev: null,
+          results: []
+        }
+      }
+    })
+  );
+  getFilteredArticles(["ah", "search", "title=tev", "author=benson"]).then(
+    data => {
+      expect(console.log).toBeCalled();
+      expect(console.log).toHaveBeenCalledWith({
+        data: {
+          count: 0,
+          next: null,
+          prev: null,
+          results: []
+        }
+      });
+    }
+  );
+});
+
+test("should return an error when there is an issue retrieving the filtered articles", () => {
+  axios.get.mockImplementationOnce(() =>
+    Promise.reject({
+      error: {}
+    })
+  );
+
+  getFilteredArticles(["ah", "search", "title=tev", "author=benson"]).then(
+    data => {
+      expect(console.log).toBeCalled();
+      expect(console.log).toHaveBeenCalledWith(
+        "❗❗ Something went wrong fetching the filtered articles."
+      );
+    }
+  );
 });

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,9 @@
 const io = require("./src/io");
-const { getAllArticles, getSingleArticle } = require("./src/fetch");
+const {
+  getAllArticles,
+  getSingleArticle,
+  getFilteredArticles
+} = require("./src/fetch");
 const { fetchandsave } = require("./src");
 
 const saveToFileCallback = data => {
@@ -26,6 +30,16 @@ const stats = (function(args) {
         file: args[2],
         callback: console.log
       });
+      return;
+    case /^ah search/.test(args_string):
+      console.log("⏱️  ⏱️ Kindly wait as we get your desired article.");
+      return getFilteredArticles(args);
+    case /^ah help$/.test(args_string):
+      console.log(
+        `ℹ        Checkout
+        https://github.com/Tevinthuku/Authors-haven-cli#commands-available 
+        to see what commands are available`
+      );
       return;
     case /ah view/.test(args_string):
       console.log("⏱️  ⏱️ Kindly wait as we get your desired article.");

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -23,7 +23,20 @@ const getSingleArticle = async args => {
     });
 };
 
+const getFilteredArticles = async args => {
+  const queryparams = args.slice(2).join("&");
+  return axios
+    .get(`https://ah-premier-staging.herokuapp.com/api/articles?${queryparams}`)
+    .then(data => {
+      console.log(data.data);
+    })
+    .catch(err => {
+      console.log("❗❗ Something went wrong fetching the filtered articles.");
+    });
+};
+
 module.exports = {
   getAllArticles,
-  getSingleArticle
+  getSingleArticle,
+  getFilteredArticles
 };


### PR DESCRIPTION
### What does this PR do?
This PR adds a command that will help in filtering the articles that are available.
eg: `node cli.js ah search author=benson title=article`
![image](https://user-images.githubusercontent.com/12128153/59566309-129fbb00-9067-11e9-9b15-4b645b097804.png)

### Context

    Flags available:


        1. author - to get posts by a specific author `author=tevin`
        2. tag - to get articles with a specific tag `tag=python`
        3. title - to get articles with a title that matches what is provided `title=flutter`
        4. page_size - determines the number of articles displayed per page. `page_size=40`


### Checklist
- [x] - add tests for fetching articles based on flags
- [x] - create functionality for filtering articles.
- [x] - create help command to guide people to repo